### PR TITLE
onDirectionChange should be optional

### DIFF
--- a/lib/auto_direction.dart
+++ b/lib/auto_direction.dart
@@ -36,7 +36,7 @@ class _AutoDirectionState extends State<AutoDirection> {
   void didUpdateWidget(AutoDirection oldWidget) {
     if (isRTL(oldWidget.text) != isRTL(widget.text)) {
       WidgetsBinding.instance!.addPostFrameCallback(
-          (_) => widget.onDirectionChange!(isRTL(widget.text)));
+          (_) => widget.onDirectionChange?.call(isRTL(widget.text)));
     }
     super.didUpdateWidget(oldWidget);
   }

--- a/lib/auto_direction.dart
+++ b/lib/auto_direction.dart
@@ -27,9 +27,9 @@ class _AutoDirectionState extends State<AutoDirection> {
   Widget build(BuildContext context) {
     text = widget.text;
     childWidget = widget.child;
-    return text.isNotEmpty ? Directionality(
+    return Directionality(
         textDirection: isRTL(text) ? TextDirection.rtl : TextDirection.ltr,
-        child: childWidget) : childWidget;
+        child: childWidget);
   }
 
   @override
@@ -42,6 +42,7 @@ class _AutoDirectionState extends State<AutoDirection> {
   }
 
   bool isRTL(String text) {
+    if (text.isEmpty) return Directionality.of(context) == TextDirection.rtl;
     return intl.Bidi.detectRtlDirectionality(text);
   }
 }

--- a/lib/auto_direction.dart
+++ b/lib/auto_direction.dart
@@ -27,9 +27,9 @@ class _AutoDirectionState extends State<AutoDirection> {
   Widget build(BuildContext context) {
     text = widget.text;
     childWidget = widget.child;
-    return Directionality(
+    return text.isNotEmpty ? Directionality(
         textDirection: isRTL(text) ? TextDirection.rtl : TextDirection.ltr,
-        child: childWidget);
+        child: childWidget) : childWidget;
   }
 
   @override


### PR DESCRIPTION
Hi, great plugin!

The parameter 'onDirectionChange' is not required, therefore we should not relay on it. But in line 39 we do: `(_) => widget.onDirectionChange!(isRTL(widget.text)));`

In this PR I fix that issue :)